### PR TITLE
CRISTALINT-7: Pages containing a "dot" character are unreachable

### DIFF
--- a/cristal-integration-webjar/src/main/node/src/components/router.ts
+++ b/cristal-integration-webjar/src/main/node/src/components/router.ts
@@ -19,7 +19,7 @@
  */
 
 import { injectable } from "inversify";
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHashHistory } from "vue-router";
 import type { RouterFactory } from "@xwiki/cristal-lib";
 import type { Container } from "inversify";
 import type { RouteRecordRaw, Router } from "vue-router";
@@ -28,7 +28,7 @@ import type { RouteRecordRaw, Router } from "vue-router";
 class XWikiRouterFactory implements RouterFactory {
   initializeRouter(routes: RouteRecordRaw[]): Router {
     const router = createRouter({
-      history: createWebHistory("/xwiki/cristal"),
+      history: createWebHashHistory("/xwiki/cristal"),
       routes,
     });
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTALINT-7

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Switch back to using hash history for vue-router.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

~~This still requires to use a patch for now. The configuration name is completely removed of pages URLs, but configurations are still not supported anyway (see https://jira.xwiki.org/browse/CRISTALINT-3).~~

~~On this own, this PR doesn't actually fix the issue due to the following regression: https://jira.xwiki.org/browse/CRISTAL-693~~

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->