### PR TITLE
CRISTALINT-20: Broken URL when switching to Cristal through keyboard shortcut

### DIFF
--- a/cristal-integration-ui/src/main/resources/CristalIntegration/Code/CristalIntegrationUIX.xml
+++ b/cristal-integration-ui/src/main/resources/CristalIntegration/Code/CristalIntegrationUIX.xml
@@ -130,7 +130,7 @@
   var url = "/xwiki/cristal/#/";
 
   if (xm.documentReference) {
-    const localDocumentReference = xm.documentReference.relativeTo(xm.documentReference.wiki);
+    const localDocumentReference = xm.documentReference.relativeTo(xm.documentReference.getRoot());
     url = `/xwiki/cristal/#/${XWiki.Model.serialize(localDocumentReference)}/view`;
   }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTALINT-20

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
There is no `wiki` property on DocumentReferences in the javascript API, this uses the `getRoot()` method instead.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A